### PR TITLE
Migrate to NetStandard and Net45

### DIFF
--- a/Moesif.Api.Test/ApiControllerTest.cs
+++ b/Moesif.Api.Test/ApiControllerTest.cs
@@ -25,9 +25,7 @@ namespace Moesif.Api.Test
             reqHeaders.Add("Host", "api.acmeinc.com");
             reqHeaders.Add("Accept", "*/*");
             reqHeaders.Add("Connection", "Keep-Alive");
-            reqHeaders.Add("User-Agent", "Dalvik/2.1.0 (Linux; U; Android 5.0.2; C6906 Build/14.5.A.0.242)");
             reqHeaders.Add("Content-Type", "application/json");
-            reqHeaders.Add("Content-Length", "126");
             reqHeaders.Add("Accept-Encoding", "gzip");
 
             var reqBody = ApiHelper.JsonDeserialize<object>(@" {
@@ -44,7 +42,6 @@ namespace Moesif.Api.Test
                 }");
 
             var rspHeaders = new Dictionary<string, string>();
-            rspHeaders.Add("Date", "Tue, 20 Aug 2019 23:46:49 GMT");
             rspHeaders.Add("Vary", "Accept-Encoding");
             rspHeaders.Add("Pragma", "no-cache");
             rspHeaders.Add("Expires", "-1");
@@ -86,9 +83,9 @@ namespace Moesif.Api.Test
             {
                 Request = eventReq,
                 Response = eventRsp,
-                UserId = "my_user_id",
-                CompanyId = "my_company_id",
-                SessionToken = "23jdf0owekfmcn4u3qypxg09w4d8ayrcdx8nu2ng]s98y18cx98q3yhwmnhcfx43f",
+                UserId = "123456",
+                CompanyId = "67890",
+                SessionToken = "XXXXXXXXX",
                 Metadata = metadata
             };
 
@@ -238,7 +235,7 @@ namespace Moesif.Api.Test
                 UserId = "1234",
                 CompanyId = "6789",
                 Metadata = metadata,
-                SessionToken = "23jdf0owekfmcn4u3qypxg09w4d8ayrcdx8nu2ng]s98y18cx98q3yhwmnhcfx43f",
+                SessionToken = "XXXXXXXXX",
                 ModifiedTime = DateTime.UtcNow
             };
 

--- a/Moesif.Api.Test/ControllerTestBase.cs
+++ b/Moesif.Api.Test/ControllerTestBase.cs
@@ -44,7 +44,7 @@ namespace Moesif.Api.Test
             {
                 if (client == null)
                 {
-                    client = new MoesifApiClient("eyJhcHAiOiIzNjU6NiIsInZlciI6IjIuMCIsIm9yZyI6IjM1OTo0IiwiaWF0IjoxNDczMzc5MjAwfQ.9WOx3D357PGMxrXzFm3pV3IzJSYNsO4oRudiMI8mQ3Q");
+                    client = new MoesifApiClient("Your Moesif Application Id");
                 }
                 return client;
             }

--- a/Moesif.Api/Moesif.Api.csproj
+++ b/Moesif.Api/Moesif.Api.csproj
@@ -1,38 +1,7 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RootNamespace>Moesif.Api</RootNamespace>
-    <AssemblyName>Moesif.Api</AssemblyName>
-    <OutputType>Library</OutputType>
-    <OutputPath>bin/DEBUG/</OutputPath>
-    <ProjectGuid>{20962015-F6CA-43BC-9D33-897C6648B556}</ProjectGuid>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <NuGetPackageImportStamp>ee2bb91c</NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+	<TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -40,74 +9,27 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>Moesif.Api.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+win8+wp8+wpa81\System.IO.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+win8+wp8+wpa81\System.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+win8+wp8+wpa81\System.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="unirest-net">
-      <HintPath>..\packages\Unirest-APIMATIC.1.0.1.26\lib\portable-net40+sl5+wp80+win8+wpa81\unirest-net.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Models\EventRequestModel.cs" />
-    <Compile Include="Models\EventModel.cs" />
-    <Compile Include="Models\EventResponseModel.cs" />
-    <Compile Include="Models\StatusModel.cs" />
-    <Compile Include="Controllers\ApiController.cs" />
-    <Compile Include="Controllers\HealthController.cs" />
-    <Compile Include="Http\Client\IHTTPClient.cs" />
-    <Compile Include="Http\Client\UnirestClient.cs" />
-    <Compile Include="Http\Client\HttpEventHandlers.cs" />
-    <Compile Include="Http\Client\HttpContext.cs" />
-    <Compile Include="Http\Request\HttpRequest.cs" />
-    <Compile Include="Http\Request\HttpMethod.cs" />
-    <Compile Include="Http\Response\HttpResponse.cs" />
-    <Compile Include="Http\Response\HttpStringResponse.cs" />
-    <Compile Include="Http\Client\FileStreamInfo.cs" />
-    <Compile Include="Controllers\BaseController.cs" />
-    <Compile Include="Configuration.cs" />
-    <Compile Include="ApiHelper.cs" />
-    <Compile Include="Exceptions\APIException.cs" />
-    <Compile Include="MoesifApiClient.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+		<PackageReference Include="Unirest-APIMATIC" Version="1.0.1.26" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+		<Reference Include="System"/>
+		<Reference Include="System.Net.Http"/>
+	</ItemGroup>
+    <ItemGroup>
+	    <Folder Include="Models\" />
+	    <Folder Include="Controllers\" />
+	    <Folder Include="Http\Client\" />
+	    <Folder Include="Http\Request\" />
+	    <Folder Include="Http\Response" />
+		<Folder Include="Exceptions" />
+		<Folder Include="Properties" />
     <None Include="app.config" />
     <None Include="Moesif.Api.nuspec" />
     <None Include="Moesif.Api.snk" />
     <None Include="packages.config" />
-    <Compile Include="Models\UserModel.cs" />
-    <Compile Include="Models\CompanyModel.cs" />
-    <Compile Include="Models\CampaignModel.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="$(SolutionDir)\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-  </Target>
 </Project>

--- a/Moesif.Api/Moesif.Api.nuspec
+++ b/Moesif.Api/Moesif.Api.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Moesif.Api</id>
-    <version>1.1.9</version>
+    <version>2.0.0</version>
     <title>MoesifApi</title>
     <authors>Moesif</authors>
     <owners>Moesif</owners>
@@ -13,20 +13,23 @@
     <description>Log API Calls to Moesif API Analytics</description>
     <summary />
     <releaseNotes />
-    <copyright>Copyright 2019</copyright>
+	<copyright>Copyright 2020</copyright>
     <language>en-US</language>
-    <tags>moesif restful rest graphql web3 api analytics log logging error debug</tags>
-    <dependencies>
-    <dependency id="Microsoft.Bcl" version="1.1.10" />
-    <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-    <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
-    <dependency id="Microsoft.Net.Http" version="2.2.29" />
-    <dependency id="Newtonsoft.Json" version="9.0.1" />
-    <dependency id="Unirest-APIMATIC" version="1.0.1.26" />
-    </dependencies>
+	  <tags>azure web app moesif API analytics insights debug debugging log logging apm performance monitor monitoring restful rest graphql ethereum web3 json-rpc soap net microsoft</tags>
+	  <dependencies>
+		  <group targetFramework="netstandard2.0">
+			  <dependency id="Newtonsoft.Json" version="9.0.1" />
+			  <dependency id="Unirest-APIMATIC" version="1.0.1.26" />
+		  </group>
+		  <group targetFramework="net45">
+			  <dependency id="Newtonsoft.Json" version="9.0.1" />
+			  <dependency id="Unirest-APIMATIC" version="1.0.1.26" />
+		  </group>
+	  </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\Moesif.Api.dll" target="lib\Moesif.Api.dll" />
+	<file src="bin\Release\netstandard2.0\Moesif.Api.dll" target="lib\netstandard2.0\Moesif.Api.dll" />
+	<file src="bin\Release\net45\Moesif.Api.dll" target="lib\net45\Moesif.Api.dll" />  
     <file src="..\README.md" target="readme.txt" />
     <file src="..\LICENSE" target="LICENSE" />
   </files>

--- a/Moesif.Api/Properties/AssemblyInfo.cs
+++ b/Moesif.Api/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Moesif, Inc")]
 [assembly: AssemblyProduct("Moesif.Api")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 // Version information for an assembly consists of the following four values:
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.9")]
-[assembly: AssemblyFileVersion("1.1.9")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]

--- a/Moesif.Api/packages.config
+++ b/Moesif.Api/packages.config
@@ -4,6 +4,4 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable4-net4+win8+wpa81" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable4-net4+win8+wpa81" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable4-net4+win8+wpa81" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable4-net4+win8+wpa81" />
-  <package id="Unirest-APIMATIC" version="1.0.1.26" targetFramework="portable4-net4+win8+wpa81" />
 </packages>


### PR DESCRIPTION
Remove BCL libraries and migrate PCL to NetStandard SDK.
This also breaks support for .NET 4.